### PR TITLE
Remove hard-coded OpenAI key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 ocr
+
+## Configuration
+
+Set the OpenAI API key in the environment variable `OPENAI_API_KEY` before running the application:
+
+```bash
+export OPENAI_API_KEY=your-api-key
+```
+
+The application reads this variable at runtime to authenticate with the OpenAI API.

--- a/ocr.py
+++ b/ocr.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import streamlit as st
 from PIL import Image
@@ -8,8 +9,8 @@ import pandas as pd
 import io
 import re
 
-# Configura aquí tu clave de API de OpenAI
-openai_api_key = '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'
+# Carga la clave de API de OpenAI desde la variable de entorno ``OPENAI_API_KEY``
+openai_api_key = os.getenv("OPENAI_API_KEY")
 
 def make_unique_columns(columns):
     """Función para hacer que los nombres de las columnas sean únicos."""


### PR DESCRIPTION
## Summary
- remove the API key from `ocr.py`
- read `OPENAI_API_KEY` from the environment
- document expected environment variable in README

## Testing
- `python -m py_compile ocr.py`

------
https://chatgpt.com/codex/tasks/task_e_6863f38477088323912909b35929594f