### PR TITLE
Add openai dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pdf2image
 pdfplumber
 pandas
 xlsxwriter
+
+openai==1.3.7


### PR DESCRIPTION
## Summary
- add `openai==1.3.7` to `requirements.txt`

## Testing
- `python3 -m pip install --disable-pip-version-check -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6863f3a579008323ae5175c562c8cbdc