### PR TITLE
Update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ pip install -r requirements.txt
 ```
 
 La aplicación necesita Tesseract OCR instalado en el sistema para procesar las imágenes.
+- **Linux**: `sudo apt-get install tesseract-ocr`
+- **macOS**: `brew install tesseract`
+- **Windows**: Descargue el instalador desde [Tesseract at UB Mannheim](https://github.com/UB-Mannheim/tesseract/wiki) y siga las instrucciones.
+
+Asegúrese de que el ejecutable `tesseract` esté disponible en su variable de entorno `PATH`.
 
 ## Configuración
 


### PR DESCRIPTION
## Summary
- mention OS-specific commands for installing Tesseract
- note that the `tesseract` executable must be on the PATH

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6863fac228fc832391844a892fe0d076